### PR TITLE
Fixed being unable to open shop if in buy zone on wave end

### DIFF
--- a/entities/entities/trigger_horde_buyzone/init.lua
+++ b/entities/entities/trigger_horde_buyzone/init.lua
@@ -1,5 +1,6 @@
 ENT.Type = "brush"
 
+local BuyZonePlayers = {} -- Keeps track of everyone in a buy zone
 function ENT:StartTouch(ent)
 	if ent:IsPlayer() then
 		if HORDE.current_break_time > 0 then
@@ -7,13 +8,24 @@ function ENT:StartTouch(ent)
 		else
 			ent:Horde_SetInBuyZone(false)
 		end
+		BuyZonePlayers[ ent ] = true
 	end
 end
 
 function ENT:EndTouch(ent)
 	if ent:IsPlayer() then
+		BuyZonePlayers[ ent ] = nil
 		ent:Horde_SetInBuyZone(false)
 		net.Start("Horde_ForceCloseShop")
-    	net.Send(ent)
+    		net.Send(ent)
 	end
 end
+
+-- Fixes people being unable to buy items if they are inside the buy zone when the wave ends unless they exit and re-enter
+hook.Add("HordeWaveEnd", "FixBuyZone", function()
+	for ply , bool in pairs( BuyZonePlayers ) do
+		if ply:IsValid() then
+			ply:Horde_SetInBuyZone(true)
+		end
+	end
+end)


### PR DESCRIPTION
Added a local table to keep track of all players that are in a buy zone, and then enabled buying from shop on them after the wave ends using a 'HordeWaveEnd' hook